### PR TITLE
Opintosuorituksen opiskeluoikeuden pakollisuuden kommentti korjattu v…

### DIFF
--- a/XML-skeemat/Opintosuoritukset.xsd
+++ b/XML-skeemat/Opintosuoritukset.xsd
@@ -322,7 +322,7 @@
 	<xs:attribute name="opiskeluoikeusAvain" type="virta:AvainTyyppi" use="optional">
 		<xs:annotation>
 			<xs:documentation xml:lang="fi">
-				Opintosuoritukseen liittyvän opiskeluoikeuden avain. Valinnainen, mutta pakollinen tutkinnoilla.
+				Opintosuoritukseen liittyvän opiskeluoikeuden avain. Olennainen tutkinnoilla, mutta vanhat puuttuvat ok, mikäli tietoa ei ole saatavissa.
 			</xs:documentation>
 		</xs:annotation>
 	</xs:attribute>


### PR DESCRIPTION
…astaamaan todellisuutta.

"Opintosuoritukseen liittyvän opiskeluoikeuden avain. Valinnainen, mutta pakollinen tutkinnolla." ->
"Opintosuoritukseen liittyvän opiskeluoikeuden avain. Olennainen tutkinnoilla, mutta vanhat puuttuvat ok, mikäli tietoa ei ole saatavissa." Peruste: Jira-tiketit CSCVIRTAOTP-2872, CSCTIE-953